### PR TITLE
#8 Feat: 구글 로그인 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
+        "axios": "^1.7.9",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.1",
@@ -3289,6 +3290,11 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3311,6 +3317,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -3614,6 +3630,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3832,6 +3859,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -4697,6 +4732,25 @@
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4704,6 +4758,19 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -5726,6 +5793,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -6204,6 +6290,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "axios": "^1.7.9",
+        "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
+        "react-cookie": "^7.2.2",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.1.1",
         "recoil": "^0.7.7",
@@ -2648,6 +2650,15 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2683,14 +2694,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5622,6 +5631,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6349,6 +6366,19 @@
       },
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
+      }
+    },
+    "node_modules/react-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.2.2.tgz",
+      "integrity": "sha512-e+hi6axHcw9VODoeVu8WyMWyoosa1pzpyjfvrLdF7CexfU+WSGZdDuRfHa4RJgTpfv3ZjdIpHE14HpYBieHFhg==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-docgen": {
@@ -7436,6 +7466,23 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
+      "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "axios": "^1.7.9",
+        "dotenv": "^16.4.7",
         "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-cookie": "^7.2.2",
@@ -3913,6 +3914,17 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
+    "axios": "^1.7.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "axios": "^1.7.9",
+    "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
+    "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.1",
     "recoil": "^0.7.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "axios": "^1.7.9",
+    "dotenv": "^16.4.7",
     "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-cookie": "^7.2.2",

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -1,0 +1,3 @@
+import defaultInstance from '@/apis/axiosInstance';
+
+const response = await defaultInstance.post('/api/auth/signup');

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -1,3 +1,20 @@
 import defaultInstance from '@/apis/axiosInstance';
 
-const response = await defaultInstance.post('/api/auth/signup');
+export const signupUser = async (signupData: {
+  year: number;
+  month: number;
+  day: number;
+  gender: string;
+  phoneNumber: string;
+  mbti: string;
+  studentNumber: number;
+  nickname: string;
+}) => {
+  try {
+    const response = await defaultInstance.post('/api/auth/signup', signupData);
+    return response.data;
+  } catch (error) {
+    console.error('회원가입 요청 중 오류가 발생했습니다.', error);
+    throw error;
+  }
+};

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -1,5 +1,10 @@
 import defaultInstance from '@/apis/axiosInstance';
 
+export const getUserRole = async () => {
+  const response = await defaultInstance.get('/api/auth/info');
+  return response.data;
+};
+
 export const signupUser = async (signupData: {
   year: number | null;
   month: number | null;

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -1,13 +1,13 @@
 import defaultInstance from '@/apis/axiosInstance';
 
 export const signupUser = async (signupData: {
-  year: number;
-  month: number;
-  day: number;
+  year: number | null;
+  month: number | null;
+  day: number | null;
   gender: string;
   phoneNumber: string;
   mbti: string;
-  studentNumber: number;
+  studentNumber: number | null;
   nickname: string;
 }) => {
   try {

--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -11,7 +11,15 @@ export const signupUser = async (signupData: {
   nickname: string;
 }) => {
   try {
-    const response = await defaultInstance.post('/api/auth/signup', signupData);
+    const formattedSignupData = {
+      ...signupData,
+      phoneNumber: signupData.phoneNumber.replace(/-/g, ''),
+    };
+
+    const response = await defaultInstance.post(
+      '/api/auth/signup',
+      formattedSignupData
+    );
     return response.data;
   } catch (error) {
     console.error('회원가입 요청 중 오류가 발생했습니다.', error);

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -4,6 +4,9 @@ const defaultInstance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
   withCredentials: true,
   timeout: 3000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
 
 export default defaultInstance;

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const defaultInstance = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL,
+  withCredentials: true,
+});
+
+defaultInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error.response?.status === 401) {
+      console.error('Error: 401 -인증 실패');
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default defaultInstance;

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -4,9 +4,6 @@ const defaultInstance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
   withCredentials: true,
   timeout: 3000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
 });
 
 export default defaultInstance;

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -3,16 +3,10 @@ import axios from 'axios';
 const defaultInstance = axios.create({
   baseURL: import.meta.env.VITE_BASE_URL,
   withCredentials: true,
+  timeout: 3000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
-
-defaultInstance.interceptors.response.use(
-  (response) => response,
-  async (error) => {
-    if (error.response?.status === 401) {
-      console.error('Error: 401 -인증 실패');
-    }
-    return Promise.reject(error);
-  }
-);
 
 export default defaultInstance;

--- a/src/components/SignUp/BirthdayGenderStep.tsx
+++ b/src/components/SignUp/BirthdayGenderStep.tsx
@@ -43,10 +43,11 @@ const BirthdayGenderStep: React.FC = () => {
     { label: '일', key: 'day', maxLength: 2, width: '40px' },
   ];
 
-  const handleInputChange = (key: string, value: string) => {
+  const handleInputChange = (key: keyof typeof signupState, value: string) => {
+    const numericValue = value === '' ? null : parseInt(value, 10);
     setSignupState((prev) => ({
       ...prev,
-      [key]: value,
+      [key]: numericValue,
     }));
   };
 
@@ -108,7 +109,9 @@ const BirthdayGenderStep: React.FC = () => {
                 type="text"
                 maxLength={maxLength}
                 width={width}
-                value={signupState[key]}
+                value={
+                  signupState[key] !== null ? signupState[key]?.toString() : ''
+                }
                 onChange={(e) => handleInputChange(key, e.target.value)}
                 onBlur={() => handleBlur(key)}
               />

--- a/src/components/SignUp/BirthdayGenderStep.tsx
+++ b/src/components/SignUp/BirthdayGenderStep.tsx
@@ -121,9 +121,9 @@ const BirthdayGenderStep: React.FC = () => {
 
       <SelectButtonContainer>
         <Button
-          onClick={() => handleGenderClick('남성')}
+          onClick={() => handleGenderClick('MALE')}
           variant={
-            signupState.gender === '남성' ? 'primary' : 'primary-outline'
+            signupState.gender === 'MALE' ? 'primary' : 'primary-outline'
           }
           size="lg"
           rounded="sm"
@@ -131,9 +131,9 @@ const BirthdayGenderStep: React.FC = () => {
           남성
         </Button>
         <Button
-          onClick={() => handleGenderClick('여성')}
+          onClick={() => handleGenderClick('FEMALE')}
           variant={
-            signupState.gender === '여성' ? 'primary' : 'primary-outline'
+            signupState.gender === 'FEMALE' ? 'primary' : 'primary-outline'
           }
           size="lg"
           rounded="sm"

--- a/src/components/SignUp/ProfileImgStep.tsx
+++ b/src/components/SignUp/ProfileImgStep.tsx
@@ -75,8 +75,7 @@ const ProfileImgStep: React.FC = () => {
       };
       const response = await signupUser(signupData);
       console.log('회원가입 성공: ', response);
-      setIsPolicyModalOpen(false);
-      nav('/home');
+      setIsPolicyModalOpen(true);
     } catch (error) {
       console.error('회원가입 실패: ', error);
     }

--- a/src/components/SignUp/ProfileImgStep.tsx
+++ b/src/components/SignUp/ProfileImgStep.tsx
@@ -15,6 +15,7 @@ import { useRecoilState } from 'recoil';
 import { signupAtom } from '@/recoil/atoms/userAtom';
 import { useNavigate } from 'react-router-dom';
 import PolicyAgreementStep from './PolicyAgreementStep';
+import { signupUser } from '@/apis/auth/auth';
 
 const ProfileImgStep: React.FC = () => {
   const nav = useNavigate();
@@ -60,9 +61,24 @@ const ProfileImgStep: React.FC = () => {
     handleCloseModal();
   };
 
-  const handleProceedToPolicy = () => {
-    if (signupState.profilePhoto) {
-      setIsPolicyModalOpen(true);
+  const handleProceedToPolicy = async () => {
+    try {
+      const signupData = {
+        year: signupState.year,
+        month: signupState.month,
+        day: signupState.day,
+        gender: signupState.gender,
+        phoneNumber: signupState.phoneNumber,
+        mbti: signupState.mbti,
+        studentNumber: signupState.studentNumber,
+        nickname: signupState.nickname,
+      };
+      const response = await signupUser(signupData);
+      console.log('회원가입 성공: ', response);
+      setIsPolicyModalOpen(false);
+      nav('/home');
+    } catch (error) {
+      console.error('회원가입 실패: ', error);
     }
   };
 
@@ -87,9 +103,7 @@ const ProfileImgStep: React.FC = () => {
           <ProfileImage
             imageUrl={signupState.profilePhoto || ''}
             onClick={handleOpenModal}
-          >
-            {!signupState.profilePhoto && <span>+</span>}
-          </ProfileImage>
+          ></ProfileImage>
           <HiddenFileInput
             id="fileInput"
             type="file"

--- a/src/components/SignUp/SignupInput.tsx
+++ b/src/components/SignUp/SignupInput.tsx
@@ -3,7 +3,7 @@ import { InputField } from '@/styles/SignUp/SignUp.styled';
 interface InputProps {
   type?: string;
   placeholder?: string;
-  value?: string;
+  value?: string | number | null | undefined;
   maxLength?: number;
   inputMode?:
     | 'none'
@@ -34,12 +34,13 @@ const SignUpInput: React.FC<InputProps> = ({
   width,
   ...props
 }) => {
+  const sanitizedValue = value !== null && value !== undefined ? value : '';
   return (
     <div>
       <InputField
         type={type}
         placeholder={placeholder}
-        value={value}
+        value={sanitizedValue.toString()}
         maxLength={maxLength}
         inputMode={inputMode}
         onChange={onChange}

--- a/src/components/SignUp/StudentIdStep.tsx
+++ b/src/components/SignUp/StudentIdStep.tsx
@@ -20,9 +20,10 @@ const StudentIdStep: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   const handleInputChange = (value: string) => {
-    setSignupState((prev) => ({ ...prev, studentId: value }));
+    const numericValue = value === '' ? null : parseInt(value, 10);
+    setSignupState((prev) => ({ ...prev, studentNumber: numericValue }));
 
-    const validationError = validateStudentId(value);
+    const validationError = validateStudentId(numericValue);
     setErrorMessage(validationError || '');
   };
 
@@ -32,7 +33,7 @@ const StudentIdStep: React.FC = () => {
     }
   };
 
-  const isFormValid = isStudentIdValid(signupState.studentId);
+  const isFormValid = isStudentIdValid(signupState.studentNumber);
   return (
     <div>
       <MainTitle>학교 인증을 위해</MainTitle>
@@ -47,7 +48,7 @@ const StudentIdStep: React.FC = () => {
           inputMode="numeric"
           maxLength={9}
           placeholder="ex) 202534999"
-          value={signupState.studentId}
+          value={signupState.studentNumber}
           onChange={(e) => handleInputChange(e.target.value)}
         />
       </InputContainer>

--- a/src/components/common/Error/InputErrorMessage.tsx
+++ b/src/components/common/Error/InputErrorMessage.tsx
@@ -16,7 +16,6 @@ export const ErrorContainer = styled.span`
 `;
 
 const InputErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => {
-  if (!message) return null;
   return (
     <ErrorContainer>
       <img src={errorCheck} alt="check-icon" />

--- a/src/pages/SignUpPage/Intro.tsx
+++ b/src/pages/SignUpPage/Intro.tsx
@@ -4,16 +4,13 @@ import GoogleIcon from '@/assets/images/GoogleIcon.svg';
 import * as S from '@/styles/SignUp/IntroPage.styled';
 
 const onClickToLogin = () => {
-  const clientId = import.meta.env.VITE_GOOGLE_AUTH_CLIENT_ID;
-  const redirectUri = import.meta.env.VITE_GOOGLE_AUTH_REDIRECT_URI;
-  console.log('client ID: ', clientId);
-  console.log('Redirect URI: ', redirectUri);
+  const baseUrl = import.meta.env.VITE_BASE_URL;
 
-  const googlOAuthUrl = `http://localhost:8080/oauth2/authorize/google?&redirect_uri=${redirectUri}`;
-
-  window.location.href = googlOAuthUrl;
+  const googleOAuthUrl = `${baseUrl}/oauth2/authorization/google`;
+  window.location.href = googleOAuthUrl;
 };
-const IntroPage: React.FC = () => {
+
+const Intro: React.FC = () => {
   return (
     <S.Container>
       <S.ContentWrapper>
@@ -43,4 +40,4 @@ const IntroPage: React.FC = () => {
   );
 };
 
-export default IntroPage;
+export default Intro;

--- a/src/pages/SignUpPage/Intro.tsx
+++ b/src/pages/SignUpPage/Intro.tsx
@@ -4,15 +4,12 @@ import GoogleIcon from '@/assets/images/GoogleIcon.svg';
 import * as S from '@/styles/SignUp/IntroPage.styled';
 
 const onClickToLogin = () => {
-  const clientId = import.meta.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID;
-  const redirectUri = import.meta.env.REACT_APP_GOOGLE_AUTH_REDIRECT_URI;
+  const clientId = import.meta.env.VITE_GOOGLE_AUTH_CLIENT_ID;
+  const redirectUri = import.meta.env.VITE_GOOGLE_AUTH_REDIRECT_URI;
   console.log('client ID: ', clientId);
   console.log('Redirect URI: ', redirectUri);
 
-  const googlOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?&response_type=code
-		&client_id=${clientId}
-		&redirect_uri=${redirectUri}
-		&scope=email profile`;
+  const googlOAuthUrl = `http://localhost:8080/oauth2/authorize/google?&redirect_uri=${redirectUri}`;
 
   window.location.href = googlOAuthUrl;
 };

--- a/src/pages/SignUpPage/Intro.tsx
+++ b/src/pages/SignUpPage/Intro.tsx
@@ -3,6 +3,19 @@ import Button from '@/components/common/Button/Button';
 import GoogleIcon from '@/assets/images/GoogleIcon.svg';
 import * as S from '@/styles/SignUp/IntroPage.styled';
 
+const onClickToLogin = () => {
+  const clientId = import.meta.env.REACT_APP_GOOGLE_AUTH_CLIENT_ID;
+  const redirectUri = import.meta.env.REACT_APP_GOOGLE_AUTH_REDIRECT_URI;
+  console.log('client ID: ', clientId);
+  console.log('Redirect URI: ', redirectUri);
+
+  const googlOAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?&response_type=code
+		&client_id=${clientId}
+		&redirect_uri=${redirectUri}
+		&scope=email profile`;
+
+  window.location.href = googlOAuthUrl;
+};
 const IntroPage: React.FC = () => {
   return (
     <S.Container>
@@ -23,9 +36,10 @@ const IntroPage: React.FC = () => {
           color="black"
           rounded="md"
           svgIcon
+          onClick={onClickToLogin}
         >
           <img src={GoogleIcon} alt="google-icon" />
-          Google로 가입
+          Google 계정으로 시작하기
         </Button>
       </S.ButtonWrapper>
     </S.Container>

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -8,7 +8,7 @@ const LoginCallback: React.FC = () => {
   useEffect(() => {
     const handleLoginResponse = async () => {
       try {
-        const response = await defaultInstance.post('/api/auth/info');
+        const response = await defaultInstance.get('/api/auth/info');
         console.log('API 응답: ', response.data);
         const { role } = response.data.result;
 

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -8,7 +8,8 @@ const LoginCallback: React.FC = () => {
   useEffect(() => {
     const handleLoginResponse = async () => {
       try {
-        const response = await defaultInstance.get('/api/auth/info');
+        console.log(defaultInstance.defaults.baseURL);
+        const response = await defaultInstance.get('api/auth/info');
         console.log('API 응답: ', response.data);
         const { role } = response.data.result;
 

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -1,3 +1,5 @@
+import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
 import { useEffect } from 'react';
 import { useCookies } from 'react-cookie';
 import { useNavigate } from 'react-router-dom';
@@ -12,7 +14,56 @@ const LoginCallback: React.FC = () => {
   const [_, setCookie] = useCookies(['accessToken', 'refreshToken']);
   const nav = useNavigate();
 
-  useEffect;
+  useEffect(() => {
+    const handleLoginResponse = async () => {
+      try {
+        const res = await axios.get(window.location.href, {
+          withCredentials: true,
+        });
+
+        const accessToken = res.headers['authorization']?.replace(
+          'Bearer ',
+          ''
+        );
+        const refreshToken = res.headers['authorization-refresh']?.replace(
+          'Bearer ',
+          ''
+        );
+
+        if (!accessToken) {
+          console.error('Access Token이 없습니다.');
+          nav('/intro');
+          return;
+        }
+
+        const decoded = jwtDecode<TokenPayload>(accessToken);
+        console.log('디코딩된 JWT : ', decoded);
+
+        setCookie('accessToken', accessToken, { path: '/', maxAge: 15 * 60 });
+        if (refreshToken) {
+          setCookie('refreshToken', refreshToken, {
+            path: '/',
+            maxAge: 7 * 24 * 60 * 60,
+          });
+        }
+
+        if (decoded.role === 'USER') {
+          nav('/home');
+        } else if (decoded.role === 'GUEST') {
+          nav('/signup');
+        } else {
+          console.error('알수 없는 사용자 role: ', decoded.role);
+          nav('/intro');
+        }
+      } catch (error) {
+        console.error('로그인 처리 중 오류가 발생했습니다. ', error);
+      }
+    };
+
+    handleLoginResponse();
+  }, [setCookie, nav]);
+
+  return <div>로그인 처리 중 ...</div>;
 };
 
 export default LoginCallback;

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { useCookies } from 'react-cookie';
+import { useNavigate } from 'react-router-dom';
+
+interface TokenPayload {
+  email: string;
+  role: string;
+  exp: number;
+}
+
+const LoginCallback: React.FC = () => {
+  const [_, setCookie] = useCookies(['accessToken', 'refreshToken']);
+  const nav = useNavigate();
+
+  useEffect;
+};
+
+export default LoginCallback;

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -1,4 +1,4 @@
-import axiosInstance from '@/apis/axiosInstance';
+import defaultInstance from '@/apis/axiosInstance';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -8,7 +8,7 @@ const LoginCallback: React.FC = () => {
   useEffect(() => {
     const handleLoginResponse = async () => {
       try {
-        const response = await axiosInstance.post('/api/auth/info');
+        const response = await defaultInstance.post('/api/auth/info');
         console.log('API 응답: ', response.data);
         const { role } = response.data.result;
 

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import { jwtDecode } from 'jwt-decode';
 import { useEffect } from 'react';
 import { useCookies } from 'react-cookie';
@@ -11,59 +10,48 @@ interface TokenPayload {
 }
 
 const LoginCallback: React.FC = () => {
-  const [_, setCookie] = useCookies(['accessToken', 'refreshToken']);
+  const [cookies] = useCookies(['accessToken', 'refreshToken']);
   const nav = useNavigate();
 
   useEffect(() => {
     const handleLoginResponse = async () => {
       try {
-        const res = await axios.get(window.location.href, {
-          withCredentials: true,
-        });
-
-        const accessToken = res.headers['authorization']?.replace(
-          'Bearer ',
-          ''
-        );
-        const refreshToken = res.headers['authorization-refresh']?.replace(
-          'Bearer ',
-          ''
-        );
+        const accessToken = cookies.accessToken;
+        const refreshToken = cookies.refreshToken;
 
         if (!accessToken) {
           console.error('Access Token이 없습니다.');
-          nav('/intro');
           return;
         }
 
+        // Access Token 디코딩
         const decoded = jwtDecode<TokenPayload>(accessToken);
         console.log('디코딩된 JWT : ', decoded);
 
-        setCookie('accessToken', accessToken, { path: '/', maxAge: 15 * 60 });
-        if (refreshToken) {
-          setCookie('refreshToken', refreshToken, {
-            path: '/',
-            maxAge: 7 * 24 * 60 * 60,
-          });
-        }
+        // // 토큰 로컬스토리지에 저장
+        // localStorage.setItem('accessToken', accessToken);
+        // if (refreshToken) {
+        //   localStorage.setItem('refreshToken', refreshToken);
+        // }
 
+        // Role에 따라 페이지 이동
         if (decoded.role === 'USER') {
           nav('/home');
         } else if (decoded.role === 'GUEST') {
           nav('/signup');
         } else {
-          console.error('알수 없는 사용자 role: ', decoded.role);
+          console.error('알 수 없는 사용자 role: ', decoded.role);
           nav('/intro');
         }
       } catch (error) {
-        console.error('로그인 처리 중 오류가 발생했습니다. ', error);
+        console.error('로그인 처리 중 오류가 발생했습니다.', error);
       }
     };
 
     handleLoginResponse();
-  }, [setCookie, nav]);
+  }, [cookies, nav]);
 
-  return <div>로그인 처리 중 ...</div>;
+  return <div>로그인 처리 중...</div>;
 };
 
 export default LoginCallback;

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -8,7 +8,6 @@ const LoginCallback: React.FC = () => {
   useEffect(() => {
     const handleLoginResponse = async () => {
       try {
-        console.log(defaultInstance.defaults.baseURL);
         const response = await defaultInstance.get('/api/auth/info');
         console.log('API 응답: ', response.data);
         const { role } = response.data.result;

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -9,7 +9,7 @@ const LoginCallback: React.FC = () => {
     const handleLoginResponse = async () => {
       try {
         console.log(defaultInstance.defaults.baseURL);
-        const response = await defaultInstance.get('api/auth/info');
+        const response = await defaultInstance.get('/api/auth/info');
         console.log('API 응답: ', response.data);
         const { role } = response.data.result;
 

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -1,4 +1,4 @@
-import defaultInstance from '@/apis/axiosInstance';
+import { getUserRole } from '@/apis/auth/auth';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -8,9 +8,9 @@ const LoginCallback: React.FC = () => {
   useEffect(() => {
     const handleLoginResponse = async () => {
       try {
-        const response = await defaultInstance.get('/api/auth/info');
-        console.log('API 응답: ', response.data);
-        const { role } = response.data.result;
+        const response = await getUserRole();
+        console.log('API 응답: ', response);
+        const { role } = response.result;
 
         // Role에 따라 페이지 이동
         if (role === 'USER') {

--- a/src/pages/SignUpPage/LoginCallback.tsx
+++ b/src/pages/SignUpPage/LoginCallback.tsx
@@ -1,46 +1,24 @@
-import { jwtDecode } from 'jwt-decode';
+import axiosInstance from '@/apis/axiosInstance';
 import { useEffect } from 'react';
-import { useCookies } from 'react-cookie';
 import { useNavigate } from 'react-router-dom';
 
-interface TokenPayload {
-  email: string;
-  role: string;
-  exp: number;
-}
-
 const LoginCallback: React.FC = () => {
-  const [cookies] = useCookies(['accessToken', 'refreshToken']);
   const nav = useNavigate();
 
   useEffect(() => {
     const handleLoginResponse = async () => {
       try {
-        const accessToken = cookies.accessToken;
-        const refreshToken = cookies.refreshToken;
-
-        if (!accessToken) {
-          console.error('Access Token이 없습니다.');
-          return;
-        }
-
-        // Access Token 디코딩
-        const decoded = jwtDecode<TokenPayload>(accessToken);
-        console.log('디코딩된 JWT : ', decoded);
-
-        // // 토큰 로컬스토리지에 저장
-        // localStorage.setItem('accessToken', accessToken);
-        // if (refreshToken) {
-        //   localStorage.setItem('refreshToken', refreshToken);
-        // }
+        const response = await axiosInstance.post('/api/auth/info');
+        console.log('API 응답: ', response.data);
+        const { role } = response.data.result;
 
         // Role에 따라 페이지 이동
-        if (decoded.role === 'USER') {
+        if (role === 'USER') {
           nav('/home');
-        } else if (decoded.role === 'GUEST') {
+        } else if (role === 'GUEST') {
           nav('/signup');
         } else {
-          console.error('알 수 없는 사용자 role: ', decoded.role);
+          console.error('알 수 없는 사용자 role: ', role);
           nav('/intro');
         }
       } catch (error) {
@@ -49,7 +27,7 @@ const LoginCallback: React.FC = () => {
     };
 
     handleLoginResponse();
-  }, [cookies, nav]);
+  }, [nav]);
 
   return <div>로그인 처리 중...</div>;
 };

--- a/src/recoil/atoms/userAtom.tsx
+++ b/src/recoil/atoms/userAtom.tsx
@@ -8,19 +8,19 @@ export const signupAtom = atom<{
   phoneNumber: string;
   mbti: string;
   nickname: string;
-  studentNumber: number;
+  studentNumber: number | null;
   profilePhoto: string | undefined;
 }>({
   key: 'signupAtom',
   default: {
-    year: 0,
-    month: 0,
-    day: 0,
+    year: null,
+    month: null,
+    day: null,
     gender: '',
     phoneNumber: '',
     mbti: '',
     nickname: '',
-    studentNumber: 0,
+    studentNumber: null,
     profilePhoto: undefined,
   },
 });

--- a/src/recoil/atoms/userAtom.tsx
+++ b/src/recoil/atoms/userAtom.tsx
@@ -1,26 +1,26 @@
 import { atom } from 'recoil';
 
 export const signupAtom = atom<{
-  year: string;
-  month: string;
-  day: string;
+  year: number;
+  month: number;
+  day: number;
   gender: string;
   phoneNumber: string;
   mbti: string;
   nickname: string;
-  studentId: string;
-  profilePhoto: string | undefined; // 타입 수정
+  studentNumber: number;
+  profilePhoto: string | undefined;
 }>({
   key: 'signupAtom',
   default: {
-    year: '',
-    month: '',
-    day: '',
+    year: 0,
+    month: 0,
+    day: 0,
     gender: '',
     phoneNumber: '',
     mbti: '',
     nickname: '',
-    studentId: '',
+    studentNumber: 0,
     profilePhoto: undefined,
   },
 });

--- a/src/recoil/atoms/userAtom.tsx
+++ b/src/recoil/atoms/userAtom.tsx
@@ -1,9 +1,9 @@
 import { atom } from 'recoil';
 
 export const signupAtom = atom<{
-  year: number;
-  month: number;
-  day: number;
+  year: number | null;
+  month: number | null;
+  day: number | null;
   gender: string;
   phoneNumber: string;
   mbti: string;

--- a/src/routes/route.tsx
+++ b/src/routes/route.tsx
@@ -9,11 +9,16 @@ import NicknameStep from '@/components/SignUp/NicknameStep';
 import StudentIdStep from '@/components/SignUp/StudentIdStep';
 import ProfileImgStep from '@/components/SignUp/ProfileImgStep';
 import SignupLayout from '@/pages/SignUpPage/SignUpLayout';
+import LoginCallback from '@/pages/SignUpPage/LoginCallback';
 
 const router = createBrowserRouter([
   {
     path: '',
     element: <Intro />,
+  },
+  {
+    path: '/oauth2/callback',
+    element: <LoginCallback />,
   },
   {
     path: '/signup',

--- a/src/utils/validate-input.ts
+++ b/src/utils/validate-input.ts
@@ -120,16 +120,23 @@ export const isNicknameValid = (value: string): boolean => {
  * @param value - 입력된 학번 값
  * @returns 에러 메세지 또는 null
  */
-export const validateStudentId = (value: string): string | null => {
-  if (!/^\d*$/.test(value)) {
+export const validateStudentId = (value: number | null): string | null => {
+  if (value === null) {
+    return '학번을 입력해주세요.';
+  }
+  const valueAsString = value.toString();
+
+  if (!/^\d*$/.test(valueAsString)) {
     return '숫자만 입력 가능합니다.';
   }
-  if (!/^20[12]\d{6}$/.test(value)) {
+
+  if (!/^20[12]\d{6}$/.test(valueAsString)) {
     return '올바른 학번을 입력해주세요.';
   }
+
   return null;
 };
 
-export const isStudentIdValid = (value: string): boolean => {
+export const isStudentIdValid = (value: number | null): boolean => {
   return validateStudentId(value) === null;
 };

--- a/src/utils/validate-input.ts
+++ b/src/utils/validate-input.ts
@@ -1,15 +1,12 @@
-
 /**
  * 년도 유효성 검사
  * @param year - 입력된 년도 값
  * @returns 에러 메세지 또는 true ( 유효한 경우 )
  */
-export const validateYear = (year: string): string | true => {
-  if (!/^\d{4}$/.test(year)) return '올바른 년도를 입력해주세요.';
-  const yearNumber = +year;
+export const validateYear = (year: number | null): string | true => {
+  if (year === null) return '년도를 입력해주세요.';
   const currentYear = new Date().getFullYear();
-  if (yearNumber < 1900 || yearNumber > currentYear)
-    return '올바른 년도를 입력해주세요.';
+  if (year < 1900 || year > currentYear) return '올바른 년도를 입력해주세요.';
   return true;
 };
 
@@ -18,11 +15,9 @@ export const validateYear = (year: string): string | true => {
  * @param month - 입력된 월 값
  * @returns 에러 메세지 또는 true ( 유효한 경우 )
  */
-export const validateMonth = (month: string): string | true => {
-  if (!/^\d{1,2}$/.test(month)) return '1에서 12 사이의 숫자를 입력해주세요.';
-  const monthNumber = +month;
-  if (monthNumber < 1 || monthNumber > 12)
-    return '1에서 12 사이의 숫자를 입력해주세요.';
+export const validateMonth = (month: number | null): string | true => {
+  if (month === null) return '월을 입력해주세요.';
+  if (month < 1 || month > 12) return '1에서 12 사이의 숫자를 입력해주세요.';
   return true;
 };
 
@@ -30,30 +25,23 @@ export const validateMonth = (month: string): string | true => {
  * 일 유효성 검사
  * @param day - 입력된 일 값
  * @param year - 입력된 년도 값
- * @param month - 입력된 월 값 
+ * @param month - 입력된 월 값
  * @returns - 에러 메세지 또는 true
  */
 export const validateDay = (
-  day: string,
-  year: string,
-  month: string
+  day: number | null,
+  year: number | null,
+  month: number | null
 ): string | true => {
-  const daysInMonth = new Date(+year, +month, 0).getDate();
-  const dayNumber = +day;
+  if (day === null || year === null || month === null)
+    return '날짜를 입력해주세요.';
 
-  if (!/^\d{1,2}$/.test(day)) {
-    return '올바른 숫자를 입력해주세요.';
-  }
+  const daysInMonth = new Date(year, month, 0).getDate();
 
-  if (dayNumber < 1) {
-    return '날짜는 1 이상이어야 합니다.';
-  }
-
-  if (dayNumber < 1 || dayNumber > daysInMonth)
+  if (day < 1 || day > daysInMonth)
     return `${month}월은 ${daysInMonth}일까지입니다.`;
   return true;
 };
-
 
 /**
  *  전화번호 유효성 검사
@@ -74,9 +62,8 @@ export const validatePhoneNumber = (value: string) => {
   return numericValue.length === 11;
 };
 
-
 /**
- * MBTI 단일 입력란 
+ * MBTI 단일 입력란
  * @param value - 입력된 MBTI 값
  * @param index - 입력된 위치 인덱스 (0~3)
  * @returns true or false


### PR DESCRIPTION
- closed #8 

## 📝 Work Description

```
<구글 로그인 flow 정리> 
1. 사용자가 구글 로그인 버튼 클릭 시 구글 로그인 페이지로 redirect 
2. 가천대 계정으로 로그인 -> 백엔드에서 인증 처리 후 설정된 클라이언트 url로 redirect
(http://localhost:3000/oauth2/callback)
3. 해당 리다이렉트 페이지로 이동 시 백엔드로 api 요청 ( GET / api/auth/info)
4. 백엔드가 쿠키에 토큰을 담아서 프론트로 전달,  응답으로 사용자 상태와 관련된 정보 반환 
- role: "USER"(추가 회원가입 정보 입력 불필요) / "GUEST" ( 추가 회원가입 정보 입력 필요)
6. 응답 값 중 role 값에 따라 페이지 이동  
- USER : 바로 홈페이지로 이동 (/home) 
- GUEST: 정보입력 페이지로 이동 (/signup)
```

- 구글 로그인 시 response 값 중 role 값으로 회원가입 정보 입력이 필요한 유저인지(GUEST), 아닌지(USER)에 따라 페이지 이동하도록 구현 
-  회원가입 API 요청( POST /api/auth/signup)이 성공하면 GUEST 에서 USER로 바뀌게 되어  다음 로그인 시 바로 홈페이지로 이동하도록 구현 

- 백엔드 쪽에서 이미지 s3 관련 작업.. ? 이 아직 구현되지 않았다고 해서 회원가입 api 요청할 때 우선 프로필 사진은 빼고 보내도록 구현했습니다 
## 📸 Screenshot
![image](https://github.com/user-attachments/assets/9106998e-6192-4231-8b1c-1d8ffeacf6f7)
생년월일, 닉네임, 전화번호 등 정보 입력하여 api 요청 성공 후,  다시 해당 계정으로 로그인을 했을 때  바로 홈페이지로 리다이렉트된 스크린샷입니다

## 📣 To Reviewers
axios instance를 작성하여 api 요청 시 매번 백엔드 url을 작성하는 중복 작업을 줄였습니다. 
변수명을 defaultInstance로 작성한 이유는, 토큰값이 필요없는 경우와 필요한 경우에 따라 defaultInstance와 authInstance로 나눠서 작성하려고 했습니다! 
추가로 , axios instance 를 쓰면 interceptor를 활용하여 에러 처리나 토큰값..? 을 처리할 수 있다고 하는데 아직 이 부분은 잘 모르겠어서 좀 더 찾아보고 사용하면 좋을 것 같습니다! 
( withCredentials:true 는 쿠키 기반 인증이 가능하도록 하는 옵션입니다)